### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,20 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm run build
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: dist/public

--- a/README.md
+++ b/README.md
@@ -67,3 +67,21 @@ Preferred communication style: Simple, everyday language.
 - **TypeScript**: Full-stack type safety with path mapping and module resolution
 - **ESBuild**: Fast JavaScript bundler for production backend builds
 - **PostCSS**: CSS processing with Tailwind and Autoprefixer plugins
+
+## Running Locally
+
+```bash
+npm install
+npx tsx server/index.ts
+```
+
+The server uses the Vite dev server in middleware mode for the React client and Express for the API. Navigate to <http://localhost:3000/> to view the app.
+
+## Deploying to GitHub Pages
+
+1. Commit your changes and push to GitHub.
+2. Run `npm run deploy`. This builds the client and publishes `dist/public` to the `gh-pages` branch using the `gh-pages` package.
+3. Ensure GitHub Pages is configured to serve from the `gh-pages` branch.
+4. Visit <https://zaredos.github.io/arenaclub-site/> after the deployment completes.
+
+Deployments can also be automated using the provided GitHub Actions workflow.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "npx tsx server/index.ts",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d dist/public"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -41,6 +41,7 @@ export class MemStorage implements IStorage {
       ...insertSuggestion,
       id,
       createdAt: new Date(),
+      email: insertSuggestion.email ?? null,
     };
     this.suggestions.set(id, suggestion);
     return suggestion;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,16 +3,14 @@ import react from "@vitejs/plugin-react";
 import path from "path";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 
-export default defineConfig({
+export default defineConfig(async ({ command }) => ({
+  base: command === "build" ? "/arenaclub-site/" : "/",
   plugins: [
     react(),
     runtimeErrorOverlay(),
-    ...(process.env.NODE_ENV !== "production" &&
-    process.env.REPL_ID !== undefined
+    ...(process.env.NODE_ENV !== "production" && process.env.REPL_ID !== undefined
       ? [
-          await import("@replit/vite-plugin-cartographer").then((m) =>
-            m.cartographer(),
-          ),
+          (await import("@replit/vite-plugin-cartographer")).cartographer(),
         ]
       : []),
   ],
@@ -34,5 +32,4 @@ export default defineConfig({
       deny: ["**/.*"],
     },
   },
-  // base: "/arenaclub-site/"
-});
+}));


### PR DESCRIPTION
## Summary
- enable dynamic base path so Vite builds for GitHub Pages
- add deploy scripts and workflow to publish `dist/public` to `gh-pages`
- document local run and GitHub Pages deployment steps

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`
- `npm run build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_68a7833e2b408320a183d14fe4074e7e